### PR TITLE
Rename groupcall.txt -> groupcall.json.

### DIFF
--- a/src/settings/rageshake.js
+++ b/src/settings/rageshake.js
@@ -189,7 +189,7 @@ export function useSubmitRageshake() {
             body.append(
               "file",
               new Blob([JSON.stringify(json)], { type: "text/plain" }),
-              "groupcall.txt"
+              "groupcall.json"
             );
           }
         }


### PR DESCRIPTION
This will stop groupcall.txt looking like it's a text log file and instead indicate it's an json artifact containing current state (which it is)

The file will still be stored on the rageshake server but the extension will indicate it's actually json data. We're already putting it in the "file" part of the rageshake, not the "logs" or "compressed-logs" parts, so it's already not meant to be handled as a log file.

(This is just a neatening up to make it easier to find the json data later)

