### PR TITLE
Add button identifiers.

### DIFF
--- a/src/button/Button.jsx
+++ b/src/button/Button.jsx
@@ -82,7 +82,7 @@ export const Button = forwardRef(
 export function MicButton({ muted, ...rest }) {
   return (
     <TooltipTrigger>
-      <Button variant="toolbar" {...rest} off={muted}>
+      <Button variant="toolbar" {...rest} off={muted} id="microphoneButton">
         {muted ? <MuteMicIcon /> : <MicIcon />}
       </Button>
       {() => (muted ? "Unmute microphone" : "Mute microphone")}
@@ -93,7 +93,7 @@ export function MicButton({ muted, ...rest }) {
 export function VideoButton({ muted, ...rest }) {
   return (
     <TooltipTrigger>
-      <Button variant="toolbar" {...rest} off={muted}>
+      <Button variant="toolbar" {...rest} off={muted} id="cameraButton">
         {muted ? <DisableVideoIcon /> : <VideoIcon />}
       </Button>
       {() => (muted ? "Turn on camera" : "Turn off camera")}


### PR DESCRIPTION
This PR adds a couple of identifiers to the mic and camera buttons for use in [pixlwave/MatrixVOIP](https://github.com/pixlwave/MatrixVOIP/) to help fix https://github.com/pixlwave/MatrixVOIP/issues/1. This would allow the web view to call `document.getElementById("microphoneButton").click()` instead of toggling the device capture state. (Also means that the additional overlay in the app can be removed and everything would behave a lot more "natively").

There are very likely better ways to achieve this (I have zero experience with React), happy to update in whatever way makes sense - in the future it would be cool if the possibility of observing the mic/camera states existed to toggle hardware LEDs etc.